### PR TITLE
Various formatting fixes/changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ All 3rd party clients will update as needed.
 | Opencord | https://github.com/X1nto/OpenCord | An open-source reimplementation of the Discord Android app | [Kotlin](https://en.wikipedia.org/wiki/Kotlin_(programming_language)) | 🟢 Active |
 | Cutthecord | https://gitdab.com/distok/cutthecord | Modular Client Mod for Discord's Android app. | [Python](https://en.wikipedia.org/wiki/Python_(programming_language)), [Java](https://en.wikipedia.org/wiki/Java_(programming_language)) | 🟠 On hiatus since April 2021 |
 | Treecord | https://github.com/Treecord/Treecord | A modded Discord client for Android! |  |  🟠 On hiatus since April 2021 |
-| ~~Bluecord~~ | ~~https://bluesmods.com/bluecord/~~ | | | ⛔ Scams and spying |
+| ~~Bluecord~~ | ~~https://bluesmods.com/bluecord/~~ | | | ⛔ Malware (scams and spying) |
 
 ### iOS
 
@@ -21,21 +21,21 @@ All 3rd party clients will update as needed.
 | Enmity | https://enmity.app/ | The power of addons, all in your hand. | [Typescript](https://en.wikipedia.org/wiki/TypeScript) | 🟢 Active |
 | Discord Classic | https://github.com/cellomonster/iOS-Discord-Classic | A bare-bones Discord client for iOS 5 and 6. | [Objective-C](https://en.wikipedia.org/wiki/Objective-C) | 🔴 Discontinued |
 
-## For iOS
+## Desktop clients
 
 ### Official
 
 | Name | Link | Infos |
 | :---: | :---: | :---: |
-| Discord | https://discord.com/download | Main software |
-| Discord PTB | https://ptb.discord.com/download | Public Test Build |
-| Discord Canary | https://canary.discord.com/download | Releases Discord Beta Features earlier than PTB |
+| Discord |[[Web](https://discord.com/app)] [[Windows](https://discord.com/api/download/?platform=win)] [[macOS](https://discord.com/api/download/?platform=osx)] [[Debian/Ubuntu](https://discord.com/api/download/?platform=linux)] [[Tarball](https://discord.com/api/download/?platform=linux&format=tar.gz)] | Main software ||
+| Discord PTB | [[Web](https://ptb.discord.com/app)] [[Windows](https://discord.com/api/download/ptb?platform=win)] [[macOS](https://discord.com/api/download/ptb?platform=osx)] [[Debian/Ubuntu](https://discord.com/api/downloadptb?platform=linux)] [[Tarball](https://discord.com/api/download/ptb?platform=linux&format=tar.gz)] | Public Test Build ||
+| Discord Canary | [[Web](https://canary.discord.com/app)] [[Windows](https://discord.com/api/download/canary?platform=win)] [[macOS](https://discord.com/api/download/canary?platform=osx)] [[Debian/Ubuntu](https://discord.com/api/download/canary?platform=linux)] [[Tarball](https://discord.com/api/download/canary?platform=linux&format=tar.gz)] | Discord's [canary build](https://semaphoreci.com/blog/what-is-canary-deployment), releases features earlier than PTB |
 
 ### Modded / Mods
 
 | Name | Link | Features | Language(s) | Development Status |
 | :---: | :---: | :---: | :---: | :---: |
-| Openasar | https://github.com/GooseMod/OpenAsar | Alternative `app.asar` for Discord. Makes your client feel snappier. | [Javascript](https://en.wikipedia.org/wiki/JavaScript) | 🟢 Active |
+| OpenAsar | https://github.com/GooseMod/OpenAsar | Alternative `app.asar` for Discord. Makes your client feel snappier. | [Javascript](https://en.wikipedia.org/wiki/JavaScript) | 🟢 Active |
 | BetterDiscord | https://betterdiscord.app/ | BetterDiscord extends the functionality of DiscordApp by enhancing it with new features.  | [Javascript](https://en.wikipedia.org/wiki/JavaScript) | 🟢 Active |
 | Kernel | https://github.com/kernel-mod | A super small and fast Electron client mod with the most capability. | [Typescript](https://en.wikipedia.org/wiki/TypeScript) | 🟢 Active |
 | Powercord | https://powercord.dev/ | A lightweight Discord client mod focused on simplicity and performance. | [Javascript](https://en.wikipedia.org/wiki/JavaScript), [Typescript](https://en.wikipedia.org/wiki/TypeScript) | 🟢 Active |
@@ -44,8 +44,8 @@ All 3rd party clients will update as needed.
 | Armcord | https://github.com/armcord/armcord | ArmCord is a custom client designed to enhance your Discord experience while keeping everything lightweight. | [Typescript](https://en.wikipedia.org/wiki/TypeScript) | 🟢 Active |
 | Vizality | https://vizality.com/ | An Discord app client modification, allowing for a truly customizable experience through the use of plugins, themes, and built-in settings. *Runs on web browsers too* | [Javascript](https://en.wikipedia.org/wiki/JavaScript) | 🟢 Active *(Closed Alpha)* |
 | DiscordQt | https://github.com/ruslang02/discord-qt | A Discord desktop client powered by Node.JS and NodeGui. | [Typescript](https://en.wikipedia.org/wiki/TypeScript) | 🟠 On hiatus since July 2021 |
-| EnhancedDiscord | https://github.com/joe27g/EnhancedDiscord | A lightweight Discord client mod. | [Javascript](https://en.wikipedia.org/wiki/JavaScript) | 🔴 Abandonned |
-| Lightcord | https://github.com/Lightcord/Lightcord | Lightcord is a simple and customizable client for Discord. It includes BandagedBD, Glasstron and a discord.js-like api. | [Javascript](https://en.wikipedia.org/wiki/JavaScript), [Typescript](https://en.wikipedia.org/wiki/TypeScript) | 🔴 Discontinued and abandoned |
+| EnhancedDiscord | https://github.com/joe27g/EnhancedDiscord | A lightweight Discord client mod. | [Javascript](https://en.wikipedia.org/wiki/JavaScript) | 🔴 Abandoned |
+| Lightcord | https://github.com/Lightcord/Lightcord | Lightcord is a simple and customizable client for Discord. It includes BandagedBD, Glasstron and a discord.js-like api. | [Javascript](https://en.wikipedia.org/wiki/JavaScript), [Typescript](https://en.wikipedia.org/wiki/TypeScript) | 🔴 Discontinued, and abandoned |
 
 ### Reimplementations
 
@@ -53,37 +53,37 @@ All 3rd party clients will update as needed.
 | :---: | :---: | :---: | :---: | :---: |
 | Accord | https://github.com/evelyneee/accord | Client for modern Macs | [Swift](https://en.wikipedia.org/wiki/Swift_(programming_language)) | 🟢 Active |
 | Fast-Discord | https://github.com/EnyoYoen/Fast-Discord | Client written in C++ and Qt | [C++](https://en.wikipedia.org/wiki/C++) | 🟢 Active |
-| Disorder | https://github.com/lexffe/discorder | Command line discord client | [Go](https://en.wikipedia.org/wiki/Go_(programming_language)) | 🟠 On hiatus since November 2016 |
-| Cordless | https://github.com/Bios-Marcel/cordless | Cordless is a custom Discord client that aims to have a low memory footprint and be aimed at power-users. | [Go](https://en.wikipedia.org/wiki/Go_(programming_language)) | ⛔ Discontinued and will make you ban |
-| 6cord | https://6cord.diamondb.xyz/ | A terminal front-end for the Discord chat service | [Go](https://en.wikipedia.org/wiki/Go_(programming_language)) | 🔴 Discontinued |
-| Terminalcord | https://github.com/xynxynxyn/terminal-discord | Simple terminal client for discord with a minimal look and UI. | [Javascript](https://en.wikipedia.org/wiki/JavaScript) | 🔴 Discontinued |
-| Discord-Lite | https://github.com/therealcyber71/Discord-Lite | A Light-Weight Discord Client written in Python for developers, by developers. | [Python](https://en.wikipedia.org/wiki/Python_(programming_language)) | 🟠 On hiatus since March 2022 |
-| Pesterchum-Discord | https://github.com/henry232323/Pesterchum-Discord | A Discord client mimicking the Pesterchum chat client from Homestuck, for the few people who are still interested in that. | [Python](https://en.wikipedia.org/wiki/Python_(programming_language)) | 🟠 On hiatus since July 2020 |
-| Discordo | https://github.com/ayntgl/discordo | A lightweight, secure, and feature-rich Discord terminal client | [Go](https://en.wikipedia.org/wiki/Go_(programming_language)) | 🔴 Discontinued |
-| Discline | https://github.com/mitchweaver/Discline | A terminal Discord client that you can actually use. | [Python](https://en.wikipedia.org/wiki/Python_(programming_language)) | 🔴 Discontinued |
-| Voidcord | https://github.com/kunamech/voidcord | A lightweight and extendable Discord web client on top of Neutralinojs. | [Javascript](https://en.wikipedia.org/wiki/JavaScript) | 🟠 On hiatus since January 2022 |
 | Abaddon | https://github.com/uowuo/abaddon | Alternative Discord client made in C++ with GTK | [C++](https://en.wikipedia.org/wiki/C++) | 🟢 Active |
 | GTK4cord | https://github.com/diamondburned/gtkcord4 | GTK4 Discord client in Go, attempt #4. | [Go](https://en.wikipedia.org/wiki/Go_(programming_language)) | 🟢 Active |
-| GTK3cord | https://github.com/diamondburned/gtkcord3 | A Gtk3 Discord client in Golang | [Go](https://en.wikipedia.org/wiki/Go_(programming_language)) | 🔴 Discontinued in favor of GTK4cord |
-| Ripcord | https://cancel.fm/ripcord/ | Alternative desktop chat client for Slack (and Discord) designed for power users. | | 🟠 On hiatus since July 2021 |
-| Discordflex | https://github.com/ZenithRogue/DiscordFlex | A custom Discord client built from the ground up. | [Javascript](https://en.wikipedia.org/wiki/JavaScript), [Vue.js](https://en.wikipedia.org/wiki/Vue.js) | 🟠 On hiatus since May 2020 |
 | Unicord | https://github.com/UnicordDev/Unicord | Discord Client for Windows 10 and Windows 10 Mobile | [C#](https://en.wikipedia.org/wiki/C_Sharp_(programming_language)) | 🟢 Active |
+| Discord-Lite | https://github.com/therealcyber71/Discord-Lite | A Light-Weight Discord Client written in Python for developers, by developers. | [Python](https://en.wikipedia.org/wiki/Python_(programming_language)) | 🟠 On hiatus, since March 2022 |
+| Voidcord | https://github.com/kunamech/voidcord | A lightweight and extendable Discord web client on top of Neutralinojs. | [Javascript](https://en.wikipedia.org/wiki/JavaScript) | 🟠 On hiatus, since January 2022 |
+| Ripcord | https://cancel.fm/ripcord/ | Alternative desktop chat client for Slack (and Discord) designed for power users. | | 🟠 On hiatus, since July 2021 |
+| Pesterchum-Discord | https://github.com/henry232323/Pesterchum-Discord | A Discord client mimicking the Pesterchum chat client from Homestuck, for the few people who are still interested in that. | [Python](https://en.wikipedia.org/wiki/Python_(programming_language)) | 🟠 On hiatus since July 2020 |
+| Discordflex | https://github.com/ZenithRogue/DiscordFlex | A custom Discord client built from the ground up. | [Javascript](https://en.wikipedia.org/wiki/JavaScript), [Vue.js](https://en.wikipedia.org/wiki/Vue.js) | 🟠 On hiatus, since May 2020 |
+| Disorder | https://github.com/lexffe/discorder | Command line discord client | [Go](https://en.wikipedia.org/wiki/Go_(programming_language)) | 🟠 On hiatus, since November 2016 |
+| 6cord | https://6cord.diamondb.xyz/ | A terminal front-end for the Discord chat service | [Go](https://en.wikipedia.org/wiki/Go_(programming_language)) | 🔴 Discontinued |
+| Terminalcord | https://github.com/xynxynxyn/terminal-discord | Simple terminal client for discord with a minimal look and UI. | [Javascript](https://en.wikipedia.org/wiki/JavaScript) | 🔴 Discontinued |
+| Discordo | https://github.com/ayntgl/discordo | A lightweight, secure, and feature-rich Discord terminal client | [Go](https://en.wikipedia.org/wiki/Go_(programming_language)) | 🔴 Discontinued |
+| Discline | https://github.com/mitchweaver/Discline | A terminal Discord client that you can actually use. | [Python](https://en.wikipedia.org/wiki/Python_(programming_language)) | 🔴 Discontinued |
+| GTK3cord | https://github.com/diamondburned/gtkcord3 | A Gtk3 Discord client in Golang | [Go](https://en.wikipedia.org/wiki/Go_(programming_language)) | 🔴 Discontinued. development shifted to GTK4cord |
+| Cordless | https://github.com/Bios-Marcel/cordless | Cordless is a custom Discord client that aims to have a low memory footprint and be aimed at power-users. | [Go](https://en.wikipedia.org/wiki/Go_(programming_language)) | ⛔ Discontinued, Developer got banned during development |
 
 ## Consoles clients
 
 | Name | Link | Features | Language(s) | Development Status |
 | :---: | :---: | :---: | :---: | :---: |
 | Switchcord | https://github.com/vbe0201/switchcord | An unofficial Discord client for the Nintendo Switch console. | [C++](https://en.wikipedia.org/wiki/C++) | 🔴 Discontinued |
-| Unofficial Discord 3DS Client | https://github.com/yourWaifu/Unofficial-Discord-3DS-Client | This just a simple Discord client for the 3DS build using the `Sleepy Discord` library and the `Wslay` library. | [C++](https://en.wikipedia.org/wiki/C++) | 🟠 On hiatus since November 2017 |
-| Vitacord | https://github.com/devingDev/VitaCord | Discord Client for PS Vita / PS TV | [C++](https://en.wikipedia.org/wiki/C++) |  🟠 On hiatus since March 2018 |
-| NXCord | https://github.com/Grarak/NXCord | Unofficial Nintendo Switch Discord client | [C++](https://en.wikipedia.org/wiki/C++) | 🟠 On hiatus since April 2020 |
-| 3DiScord | https://github.com/cheuble/3DiScord | A Discord client for the Nintendo 3DS | [C++](https://en.wikipedia.org/wiki/C++) | ⛔ Discontinued and will make you ban |
+| Unofficial Discord 3DS Client | https://github.com/yourWaifu/Unofficial-Discord-3DS-Client | This just a simple Discord client for the 3DS build using the `Sleepy Discord` library and the `Wslay` library. | [C++](https://en.wikipedia.org/wiki/C++) | 🟠 On hiatus, since November 2017 |
+| Vitacord | https://github.com/devingDev/VitaCord | Discord Client for PS Vita / PS TV | [C++](https://en.wikipedia.org/wiki/C++) | 🟠 On hiatus, since March 2018 |
+| NXCord | https://github.com/Grarak/NXCord | Unofficial Nintendo Switch Discord client | [C++](https://en.wikipedia.org/wiki/C++) | 🟠 On hiatus, since April 2020 |
+| 3DiScord | https://github.com/cheuble/3DiScord | A Discord client for the Nintendo 3DS | [C++](https://en.wikipedia.org/wiki/C++) | ⛔ Discontinued. will get you banned |
 
 ## Other
 
 | Name | Link | Features | Language(s) | Development Status |
 | :---: | :---: | :---: | :---: | :---: |
-| crocodile | https://github.com/tbodt/crocodile | Discord client for TempleOS. | [Python](https://en.wikipedia.org/wiki/Python_(programming_language)) | 🟠 On hiatus since November 2017 | 
+| crocodile | https://github.com/tbodt/crocodile | Discord client for TempleOS. | [Python](https://en.wikipedia.org/wiki/Python_(programming_language)) | 🟠 On hiatus, since November 2017 |
 
 ## Further comments
 


### PR DESCRIPTION
This commit fixes grammatical issues (mainly lack of commas), sorts clients based on activity (active -> hiatus -> discontinued -> unrecommended/banned), gives the Official clients section a small redesign by adding various download links and fixes the "for iOS" thing on "Desktop clients"

Only part that I guess could cause issues is the "Official clients" overhaul, it looks a bit clunky and can overall be skipped for the sake of simplicity.