### PR TITLE
Update Discord for J2ME & logo for Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ We (contributors) are not responsible for you getting banned from using a 3rd pa
 [Go-Badge]: https://img.shields.io/badge/Go-%2300ADD8.svg?style=flat&logo=go&logoColor=white
 [Go-Url]: https://en.wikipedia.org/wiki/Go_(programming_language) "Go"
 
-[Java-Badge]: https://img.shields.io/badge/Java-%23ED8B00.svg?style=flat&logo=java&logoColor=white
+[Java-Badge]: https://img.shields.io/badge/Java-%23ED8B00.svg?style=flat&logo=openjdk&logoColor=white
 [Java-Url]: https://en.wikipedia.org/wiki/Java_(programming_language) "Java"
 
 [JavaScript-Badge]: https://img.shields.io/badge/JavaScript-%23323330.svg?style=flat&logo=javascript&logoColor=%23F7DF1E

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ A non-exhaustive collection of third-party clients and mods for Discord.
 | [Discross](http://discross.rc24.xyz/index.html) | A webhook bridge to send messages on Discord through a webpage | [![JavaSript][JavaScript-Badge]][JavaScript-Url] | 🟢 Active |
 | [purple-discord](https://github.com/EionRobb/purple-discord) | A libpurple/Pidgin plugin for Discord | [![C][C-Badge]][C-Url] | 🟢 Active |
 | [Reliable Discord-client IRC Daemon (rdircd)](https://github.com/mk-fg/reliable-discord-client-irc-daemon) | Reliable personal discord-client to irc-server translation daemon | [![Python][Python-Badge]][Python-Url] | 🟢 Active |
-| [discord-j2me](https://github.com/gtrxAC/discord-j2me) | Discord client for Java ME (MIDP 2.0) devices | [![JavaScript][JavaScript-Badge]][JavaScript-Url] | 🟢 Active |
+| [discord-j2me](https://github.com/gtrxAC/discord-j2me) | Discord client for Java ME (MIDP 1.0 & 2.0) devices | [![Java][Java-Badge]][Java-Url] | 🟢 Active |
 | [Weechat Discord](https://github.com/terminal-discord/weechat-discord) | Weechat plugin for Discord support. | [![Rust][Rust-Badge]][Rust-Url] | 🟢 Active |
 | [bitlbee-discord](https://github.com/sm00th/bitlbee-discord) | Discord protocol plugin for BitlBee. | [![C][C-Badge]][C-Url] | 🟠 On hiatus, since September 2021 |
 | [crocodile](https://github.com/tbodt/crocodile) | Discord client for TempleOS. | [![Python][Python-Badge]][Python-Url] | 🟠 On hiatus, since November 2017 |

--- a/badges.md
+++ b/badges.md
@@ -55,7 +55,7 @@ To use a badge:
 [Go-Badge]: https://img.shields.io/badge/Go-%2300ADD8.svg?style=flat&logo=go&logoColor=white
 [Go-Url]: https://en.wikipedia.org/wiki/Go_(programming_language) "Go"
 
-[Java-Badge]: https://img.shields.io/badge/Java-%23ED8B00.svg?style=flat&logo=java&logoColor=white
+[Java-Badge]: https://img.shields.io/badge/Java-%23ED8B00.svg?style=flat&logo=openjdk&logoColor=white
 [Java-Url]: https://en.wikipedia.org/wiki/Java_(programming_language) "Java"
 
 [JavaScript-Badge]: https://img.shields.io/badge/JavaScript-%23323330.svg?style=flat&logo=javascript&logoColor=%23F7DF1E


### PR DESCRIPTION
Quick summary
- Discord J2ME is made in Java and since v3.0.0 also supports MIDP 1.0 devices
- Use OpenJDK logo for Java badge (due to Java logo being deleted https://github.com/simple-icons/simple-icons/issues/7374)