### PR TITLE
Added ra1n, changed boundtweak to btloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A non-exhaustive collection of third-party clients and mods for Discord.
 | Name | Features | Language(s) | Development Status |
 | :---: | :---: | :---: | :---: |
 | [Discord iOS](https://apps.apple.com/us/app/discord-chat-talk-hangout/id985746746) | Official iOS client | [Closed source] | 🟢 Active |
-| [BTLoader](https://github.com/CloudySn0w/BTLoader) | For now provides unofficial builds of [Revenge](https://github.com/revenge-mod/Revenge) for iOS, but upon full release plans to provide [Ra1n](https://github.com/ra1ncord/ra1n) builds for iOS| [![TypeScript][TypeScript-Badge]][TypeScript-Url] | 🟢 Active |
+| [BTLoader](https://github.com/CloudySn0w/BTLoader) | Provides unofficial builds of [Revenge](https://github.com/revenge-mod/Revenge) for iOS. But will utilise [Ra1n](https://github.com/ra1ncord/ra1n) once Ra1n is fully released.| [![TypeScript][TypeScript-Badge]][TypeScript-Url] | 🟢 Active |
 | [Stossycord](https://github.com/Stossycord/Stossycord) | Stossycord is a Discord Client Native to iOS Devices. It is made in 100% Swift and SwiftUI for Privacy, Responsiveness and Security | [![Swift][Swift-Badge]][Swift-Url]    | 🟠🟢 Active *(In a very early beta)* |
 | [Unbound](https://www.unbound.rip/) | Cross-platform client modification for discord on mobile. | [![TypeScript][TypeScript-Badge]][TypeScript-Url] | 🔵 *(still in development state)* |
 | [Revenge](https://github.com/revenge-mod/Revenge) | Revenge is a fork of [Bunny](https://github.com/pyoncord/Bunny) | [![TypeScript][TypeScript-Badge]][TypeScript-Url] | 🔴 Discontinued |


### PR DESCRIPTION
**I Added Ra1n**

> Ra1n is a discord mod for Android and maybe iOS in the future, it was made after lumi got discontinued. I determined the coding language was kotlin based on this picture. 
![Screenshot_20250730_102636_Firefox](https://github.com/user-attachments/assets/f83e2901-7478-4e67-be38-38a84e1f334d)

**I Changed Bound To BTLoader**

 >The name of the GitHub repository is now BTLoader instead of BoundTweak and the link has also been updated. the repository seems that instead of providing unofficial revenge builds for iOS its going to provide ra1n builds for iOS, but it's staying to revenge builds for now.